### PR TITLE
[Fix] GreenBorder 컴포넌트 InfoPage 버전 추가

### DIFF
--- a/src/components/_common/GreenBorder.jsx
+++ b/src/components/_common/GreenBorder.jsx
@@ -1,10 +1,11 @@
 import React from 'react';
 import styled from 'styled-components';
 
-const GreenBorder = ({ text }) => {
+//infoPage에서 사용할 경우에만 type에 info를 넘겨주면 됩니다.
+const GreenBorder = ({ text, type }) => {
     return (
         <>
-            <Border>
+            <Border className={type}>
                 <Text>{text}</Text>
             </Border>
         </>
@@ -18,6 +19,11 @@ const Border = styled.div`
     border-bottom: 4px solid var(--green2);
     border-radius: 2px;
     position: relative;
+
+    &.info {
+        width: 390px;
+        border-radius: 0px;
+    }
 `;
 
 const Text = styled.div`


### PR DESCRIPTION
# 구현 기능

- GreenBorder가 정보 페이지에서 사용될때 width가 회색 박스에 맞지 않아 infoPage 버전을 추가했습니다.

# 구현 상태

![image](https://github.com/EFUB-EDAY/EDAY-FRONT/assets/109021332/7d10952c-2c9f-431f-aa3a-d48facf0b8c5)

# Resolve

# To Reviewers
infoPage에서 사용할 경우에만 type에 info를 넘겨주시면 됩니다!
``````
const GreenBorder = ({ text, type }) => {
    return (
        <>
            <Border className={type}>
                <Text>{text}</Text>
            </Border>
        </>
    );
};
`````````