### PR TITLE
[Fix] GreenBorder 메인 페이지 버전 추가

### DIFF
--- a/src/components/_common/GreenBorder.jsx
+++ b/src/components/_common/GreenBorder.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import styled from 'styled-components';
 
-//infoPage에서 사용할 경우에만 type에 info를 넘겨주면 됩니다.
+//infoPage에서 사용할 경우에는 type에 info,
+//mainPage에서 사용할 경우에는 type에 main을 넘겨주면 됩니다.
 const GreenBorder = ({ text, type }) => {
     return (
         <>
@@ -19,12 +20,15 @@ const Border = styled.div`
     border-bottom: 4px solid var(--green2);
     border-radius: 2px;
     position: relative;
-    display: flex;
-    justify-content: center;
 
     &.info {
         width: 390px;
         border-radius: 0px;
+    }
+
+    &.main {
+        display: flex;
+        justify-content: center;
     }
 `;
 

--- a/src/components/mainpage/SideBar.jsx
+++ b/src/components/mainpage/SideBar.jsx
@@ -77,7 +77,7 @@ const SideBar = props => {
                                     <Level>{`Lv.${profile.level}`}</Level>
                                 </Flex>
                             </Inner>
-                            <GreenBorder text={profile.titleName} />
+                            <GreenBorder text={profile.titleName} type='main' />
                             <Right onClick={() => nav('/mypage')}>
                                 마이페이지
                                 <BsChevronRight


### PR DESCRIPTION
# 구현 기능


GreenBorder위의 텍스트가 메인페이지에서는 중앙 정렬이고 그 외의 페이지에서는 모두 왼쪽 정렬 이어서 메인 페이지 버전을 추가했습니다.

# 구현 상태
```````````
const Border = styled.div`
    height: 0;
    border-bottom: 4px solid var(--green2);
    border-radius: 2px;
    position: relative;

    &.info {
        width: 390px;
        border-radius: 0px;
    }

    &.main {
        display: flex;
        justify-content: center;
    }
`;
````````````

# Resolve


# To Reviewers
infoPage에서 사용할 경우에는 type에 info, mainPage에서 사용할 경우에는 type에 main을 넘겨주면 됩니다. 그 외의 페이지에서는 아무것도 넘겨주지 않아도 됩니다.


